### PR TITLE
added optional `style` prop to DayPickerInputProps

### DIFF
--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -184,4 +184,5 @@ export interface DayPickerInputProps {
   onFocus?(e: React.FocusEvent<HTMLDivElement>): void;
   onBlur?(e: React.FocusEvent<HTMLDivElement>): void;
   onKeyUp?(e: React.FocusEvent<HTMLDivElement>): void;
+  style?: object;
 }


### PR DESCRIPTION
According to https://react-day-picker.js.org/api/DayPickerInput/, `style` should be a valid prop. 

However, it is missing from `DayPickerInputProps` [here](https://github.com/gpbl/react-day-picker/blob/master/types/props.d.ts).

This PR simply adds the following to `DayPickerInputProps`:

```
style?: object;
```